### PR TITLE
Import history for any review year and flag movement between calibrations

### DIFF
--- a/backend/src/ninebox/api/employees.py
+++ b/backend/src/ninebox/api/employees.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, field_validator
 from ninebox.core.dependencies import get_employee_service, get_session_manager
 from ninebox.models.employee import Employee, PerformanceLevel, PotentialLevel
 from ninebox.models.filters import EmployeeFilters
-from ninebox.services.employee_service import EmployeeService, is_big_mover
+from ninebox.services.employee_service import EmployeeService, is_big_mover, is_medium_mover
 from ninebox.services.sample_data_generator import (
     RichDatasetConfig,
     generate_rich_dataset,
@@ -179,12 +179,13 @@ async def get_employees(
     # Get original employees for in-session big mover detection
     original_employees_map = {e.employee_id: e for e in session.original_employees}
 
-    # Serialize with is_big_mover computed
+    # Serialize with movement flags computed
     employees_data = []
     for emp in filtered_employees:
         emp_dict = emp.model_dump()
         original_emp = original_employees_map.get(emp.employee_id)
         emp_dict["is_big_mover"] = is_big_mover(emp, original_emp)
+        emp_dict["is_medium_mover"] = is_medium_mover(emp, original_emp)
         employees_data.append(emp_dict)
 
     return {
@@ -387,12 +388,13 @@ async def update_employee(  # noqa: PLR0912 - Complex update logic requires mult
     if not employee:
         raise HTTPException(status_code=404, detail="Employee not found")
 
-    # Compute is_big_mover for response
+    # Compute movement flags for response
     employee_data = employee.model_dump()
     original_emp = next(
         (e for e in session.original_employees if e.employee_id == employee_id), None
     )
     employee_data["is_big_mover"] = is_big_mover(employee, original_emp)
+    employee_data["is_medium_mover"] = is_medium_mover(employee, original_emp)
 
     return {"employee": employee_data, "success": True}
 
@@ -436,7 +438,7 @@ async def move_employee(
         )
     employee = next((e for e in session.current_employees if e.employee_id == employee_id), None)
 
-    # Compute is_big_mover for response
+    # Compute movement flags for response
     employee_data = None
     if employee:
         employee_data = employee.model_dump()
@@ -444,6 +446,7 @@ async def move_employee(
             (e for e in session.original_employees if e.employee_id == employee_id), None
         )
         employee_data["is_big_mover"] = is_big_mover(employee, original_emp)
+        employee_data["is_medium_mover"] = is_medium_mover(employee, original_emp)
 
     return {
         "employee": employee_data,
@@ -523,7 +526,7 @@ async def move_employee_donut(
     # Get updated employee for response
     employee = next((e for e in session.current_employees if e.employee_id == employee_id), None)
 
-    # Compute is_big_mover for response
+    # Compute movement flags for response
     employee_data = None
     if employee:
         employee_data = employee.model_dump()
@@ -531,6 +534,7 @@ async def move_employee_donut(
             (e for e in session.original_employees if e.employee_id == employee_id), None
         )
         employee_data["is_big_mover"] = is_big_mover(employee, original_emp)
+        employee_data["is_medium_mover"] = is_medium_mover(employee, original_emp)
 
     return {
         "employee": employee_data,

--- a/backend/src/ninebox/models/employee.py
+++ b/backend/src/ninebox/models/employee.py
@@ -66,6 +66,11 @@ class Employee(BaseModel):
     grid_position: int  # 1-9
     talent_indicator: str
 
+    # Position from the previous calibration cycle, used to detect movement
+    # between calibrations (distinct from original_grid_position, which tracks
+    # movement within the current session).
+    prior_grid_position: int | None = None
+
     # Historical Performance
     ratings_history: list[HistoricalRating] = []
 

--- a/backend/src/ninebox/services/employee_service.py
+++ b/backend/src/ninebox/services/employee_service.py
@@ -1,5 +1,6 @@
 """Employee filtering and query service."""
 
+from datetime import date
 from enum import Enum
 
 from ninebox.models.employee import Employee, PerformanceLevel, PotentialLevel
@@ -151,12 +152,37 @@ def is_tier_crossing(from_tier: PerformanceTier, to_tier: PerformanceTier) -> bo
     )
 
 
+def get_most_recent_prior_year_rating(employee: Employee) -> str | None:
+    """Get the rating from the most recent *completed* review year.
+
+    Ratings for the current calendar year (or later) are excluded: the current
+    cycle's rating describes the same period as the employee's current grid
+    position, so comparing the two would report movement where none happened.
+    This matters because history is imported for any year present in the file,
+    not just the two hardcoded years it used to be limited to.
+
+    Args:
+        employee: Employee whose ratings history to inspect
+
+    Returns:
+        Rating string from the latest completed year, or None if there is none
+    """
+    current_year = date.today().year
+    completed = [entry for entry in employee.ratings_history if entry.year < current_year]
+    if not completed:
+        return None
+    return max(completed, key=lambda entry: entry.year).rating
+
+
 def is_big_mover(employee: Employee, original_employee: Employee | None = None) -> bool:
     """Determine if employee is a big mover.
 
-    Checks for two types of big moves:
-    1. Year-over-year: Prior year rating tier → current position tier crosses Low↔High
-    2. In-session: Original position tier → current position tier crosses Low↔High
+    Checks for three types of big moves:
+    1. Calibration-to-calibration: Prior calibration position tier → current position
+       tier crosses Low↔High
+    2. Year-over-year: Latest completed year's rating tier → current position tier
+       crosses Low↔High
+    3. In-session: Original position tier → current position tier crosses Low↔High
 
     Args:
         employee: Current employee data
@@ -200,10 +226,9 @@ def is_big_mover(employee: Employee, original_employee: Employee | None = None) 
         if is_tier_crossing(prior_calibration_tier, current_tier):
             return True
 
-    # Check year-over-year movement (if ratings history available)
-    if employee.ratings_history:
-        # Get most recent prior year rating
-        most_recent_rating = employee.ratings_history[-1].rating
+    # Check year-over-year movement (if a completed prior year rating exists)
+    most_recent_rating = get_most_recent_prior_year_rating(employee)
+    if most_recent_rating is not None:
         try:
             prior_tier = get_tier_from_historical_rating(most_recent_rating)
             if is_tier_crossing(prior_tier, current_tier):
@@ -270,6 +295,14 @@ def is_medium_mover(employee: Employee, original_employee: Employee | None = Non
     The two are mutually exclusive: an employee who qualifies as a big mover is
     not also reported as a medium mover, so the flags partition cleanly for
     filtering.
+
+    Note that the two flags measure different things rather than two levels of
+    one thing, so "big" does not always mean "further". Expert [H,L] to High
+    Impact [H,M] is one axis step but crosses Low to High tier, so it is big;
+    Expert [H,L] to Emerging [L,H] is the maximum four steps but stays out of
+    that crossing, so it is medium. This is intentional - a tier reversal is the
+    signal worth surfacing loudest - but it makes the pair worth reading as
+    "reversed" versus "shifted", not "more" versus "less".
 
     Args:
         employee: Current employee data

--- a/backend/src/ninebox/services/employee_service.py
+++ b/backend/src/ninebox/services/employee_service.py
@@ -194,6 +194,12 @@ def is_big_mover(employee: Employee, original_employee: Employee | None = None) 
     """
     current_tier = get_tier_from_position(employee.grid_position)
 
+    # Check movement since the previous calibration (if a prior position is known)
+    if employee.prior_grid_position:
+        prior_calibration_tier = get_tier_from_position(employee.prior_grid_position)
+        if is_tier_crossing(prior_calibration_tier, current_tier):
+            return True
+
     # Check year-over-year movement (if ratings history available)
     if employee.ratings_history:
         # Get most recent prior year rating
@@ -213,6 +219,79 @@ def is_big_mover(employee: Employee, original_employee: Employee | None = None) 
             return True
 
     return False
+
+
+def get_axis_distance(from_position: int, to_position: int) -> int:
+    """Total steps moved across the performance and potential axes.
+
+    The grid is a 3x3 of Low/Medium/High on each axis, so a move is measured as
+    the sum of the steps taken on each axis independently. This captures diagonal
+    movement that a tier comparison alone treats as a single step.
+
+    Args:
+        from_position: Starting grid position (1-9)
+        to_position: Ending grid position (1-9)
+
+    Returns:
+        Combined number of axis steps (0-4)
+
+    Examples:
+        >>> get_axis_distance(5, 5)  # Core Talent -> Core Talent
+        0
+        >>> get_axis_distance(5, 9)  # Core [M,M] -> Star [H,H]
+        2
+        >>> get_axis_distance(1, 9)  # Underperformer [L,L] -> Star [H,H]
+        4
+        >>> get_axis_distance(5, 6)  # Core [M,M] -> High Impact [H,M]
+        1
+    """
+    for position in (from_position, to_position):
+        if not 1 <= position <= 9:
+            raise ValueError(f"Invalid grid position: {position}")
+
+    from_performance, from_potential = (from_position - 1) % 3, (from_position - 1) // 3
+    to_performance, to_potential = (to_position - 1) % 3, (to_position - 1) // 3
+    return abs(to_performance - from_performance) + abs(to_potential - from_potential)
+
+
+# Total axis steps at or above which a move is considered notable but not extreme
+MEDIUM_MOVER_THRESHOLD = 2
+
+
+def is_medium_mover(employee: Employee, original_employee: Employee | None = None) -> bool:
+    """Determine if employee moved a notable but sub-Low/High distance.
+
+    Complements is_big_mover: where that flags reversals across the Low/High
+    tiers, this catches employees who shifted at least MEDIUM_MOVER_THRESHOLD
+    steps across the two axes without crossing tiers - for example Core Talent
+    [M,M] to Star [H,H], which moves on both axes but never leaves the middle
+    and high tiers.
+
+    The two are mutually exclusive: an employee who qualifies as a big mover is
+    not also reported as a medium mover, so the flags partition cleanly for
+    filtering.
+
+    Args:
+        employee: Current employee data
+        original_employee: Original employee data from file upload (for in-session detection)
+
+    Returns:
+        True if the largest available move is at least the medium threshold and
+        the employee is not already a big mover
+    """
+    if is_big_mover(employee, original_employee):
+        return False
+
+    comparison_positions = []
+    if employee.prior_grid_position:
+        comparison_positions.append(employee.prior_grid_position)
+    if original_employee is not None and original_employee.grid_position:
+        comparison_positions.append(original_employee.grid_position)
+
+    return any(
+        get_axis_distance(position, employee.grid_position) >= MEDIUM_MOVER_THRESHOLD
+        for position in comparison_positions
+    )
 
 
 class EmployeeService:

--- a/backend/src/ninebox/services/excel_exporter.py
+++ b/backend/src/ninebox/services/excel_exporter.py
@@ -322,9 +322,9 @@ class ExcelExporter:
 
             # Historical ratings - one column per review year found in the data
             for rating in emp.ratings_history:
-                col_idx = history_col_by_year.get(rating.year)
-                if col_idx is not None:
-                    data_sheet.cell(row_idx, col_idx, rating.rating)
+                history_col = history_col_by_year.get(rating.year)
+                if history_col is not None:
+                    data_sheet.cell(row_idx, history_col, rating.rating)
 
             data_sheet.cell(row_idx, trailing_start, emp.development_focus)
             data_sheet.cell(row_idx, trailing_start + 1, emp.development_action)

--- a/backend/src/ninebox/services/excel_exporter.py
+++ b/backend/src/ninebox/services/excel_exporter.py
@@ -263,8 +263,9 @@ class ExcelExporter:
         # review cycle round-trips, rather than a fixed 2023/2024 pair.
         history_years = sorted({r.year for e in employees for r in e.ratings_history})
         history_headers = [canonical_historical_rating_column(y) for y in history_years]
-        history_col_by_year = {year: 19 + offset for offset, year in enumerate(history_years)}
-        trailing_start = 19 + len(history_years)
+        prior_position_col = 19
+        history_col_by_year = {year: 20 + offset for offset, year in enumerate(history_years)}
+        trailing_start = 20 + len(history_years)
 
         # Headers - matching the expected format from ExcelParser
         headers = [
@@ -286,6 +287,7 @@ class ExcelExporter:
             "Aug 2025 Talent Assessment 9-Box Label",
             "Talent Mapping Position",
             "FY25 Talent Indicator",
+            "Prior Calibration 9-Box Label",
             *history_headers,
             "Development Focus",
             "Development Action",
@@ -316,6 +318,7 @@ class ExcelExporter:
             data_sheet.cell(row_idx, 16, emp.grid_position)
             data_sheet.cell(row_idx, 17, get_position_label_by_number(emp.grid_position))
             data_sheet.cell(row_idx, 18, emp.talent_indicator)
+            data_sheet.cell(row_idx, prior_position_col, emp.prior_grid_position)
 
             # Historical ratings - one column per review year found in the data
             for rating in emp.ratings_history:

--- a/backend/src/ninebox/services/excel_exporter.py
+++ b/backend/src/ninebox/services/excel_exporter.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from ninebox.models.employee import Employee
 from ninebox.models.grid_positions import get_position_label, get_position_label_by_number
+from ninebox.services.excel_parser import canonical_historical_rating_column
 
 if TYPE_CHECKING:
     import openpyxl
@@ -258,6 +259,13 @@ class ExcelExporter:
         # Employee data sheet
         data_sheet = workbook.create_sheet("Employee Data")
 
+        # History columns are driven by the years actually present in the data so any
+        # review cycle round-trips, rather than a fixed 2023/2024 pair.
+        history_years = sorted({r.year for e in employees for r in e.ratings_history})
+        history_headers = [canonical_historical_rating_column(y) for y in history_years]
+        history_col_by_year = {year: 19 + offset for offset, year in enumerate(history_years)}
+        trailing_start = 19 + len(history_years)
+
         # Headers - matching the expected format from ExcelParser
         headers = [
             "Employee ID",
@@ -278,8 +286,7 @@ class ExcelExporter:
             "Aug 2025 Talent Assessment 9-Box Label",
             "Talent Mapping Position",
             "FY25 Talent Indicator",
-            "2023 Completed Performance Rating",
-            "2024 Completed Performance Rating",
+            *history_headers,
             "Development Focus",
             "Development Action",
             "Notes",
@@ -310,18 +317,16 @@ class ExcelExporter:
             data_sheet.cell(row_idx, 17, get_position_label_by_number(emp.grid_position))
             data_sheet.cell(row_idx, 18, emp.talent_indicator)
 
-            # Historical ratings
-            if emp.ratings_history:
-                for rating in emp.ratings_history:
-                    if rating.year == 2023:
-                        data_sheet.cell(row_idx, 19, rating.rating)
-                    elif rating.year == 2024:
-                        data_sheet.cell(row_idx, 20, rating.rating)
+            # Historical ratings - one column per review year found in the data
+            for rating in emp.ratings_history:
+                col_idx = history_col_by_year.get(rating.year)
+                if col_idx is not None:
+                    data_sheet.cell(row_idx, col_idx, rating.rating)
 
-            data_sheet.cell(row_idx, 21, emp.development_focus)
-            data_sheet.cell(row_idx, 22, emp.development_action)
-            data_sheet.cell(row_idx, 23, emp.notes)
-            data_sheet.cell(row_idx, 24, emp.promotion_status)
+            data_sheet.cell(row_idx, trailing_start, emp.development_focus)
+            data_sheet.cell(row_idx, trailing_start + 1, emp.development_action)
+            data_sheet.cell(row_idx, trailing_start + 2, emp.notes)
+            data_sheet.cell(row_idx, trailing_start + 3, emp.promotion_status)
 
         return workbook
 

--- a/backend/src/ninebox/services/excel_parser.py
+++ b/backend/src/ninebox/services/excel_parser.py
@@ -15,6 +15,16 @@ from ninebox.models.grid_positions import calculate_grid_position
 
 logger = logging.getLogger(__name__)
 
+# Historical performance rating columns are recognized by pattern rather than by a
+# fixed list of years, so a new review cycle needs no code change. Matches e.g.
+# "2023 Completed Performance Rating", "2026 completed performance rating".
+HISTORICAL_RATING_PATTERN = re.compile(r"^(\d{4})\s+completed performance rating$", re.IGNORECASE)
+
+
+def canonical_historical_rating_column(year: int) -> str:
+    """Build the canonical header for a review year's performance rating column."""
+    return f"{year} Completed Performance Rating"
+
 
 def normalize_column_names(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -55,8 +65,6 @@ def normalize_column_names(df: pd.DataFrame) -> pd.DataFrame:
         "time in job profile": "Time in Job Profile",
         "fy25 talent indicator": "FY25 Talent Indicator",
         "talent indicator": "Talent Indicator",
-        "2023 completed performance rating": "2023 Completed Performance Rating",
-        "2024 completed performance rating": "2024 Completed Performance Rating",
         "development focus": "Development Focus",
         "development action": "Development Action",
         "notes": "Notes",
@@ -68,15 +76,32 @@ def normalize_column_names(df: pd.DataFrame) -> pd.DataFrame:
         "donut exercise notes": "Donut Exercise Notes",
     }
 
-    # Build rename mapping for columns that need normalization
+    # Build rename mapping for columns that need normalization.
+    # `claimed` guards against two source columns normalizing to the same canonical
+    # name (e.g. "Notes" and "notes "), which would produce duplicate DataFrame
+    # columns and make row lookups return a Series instead of a scalar.
     rename_mapping = {}
+    claimed = {str(col) for col in df.columns}
     for col in df.columns:
         col_lower = str(col).lower().strip()
-        if col_lower in expected_columns:
+        year_match = HISTORICAL_RATING_PATTERN.match(col_lower)
+        if year_match:
+            expected_name = canonical_historical_rating_column(int(year_match.group(1)))
+        elif col_lower in expected_columns:
             expected_name = expected_columns[col_lower]
-            if col != expected_name:
-                rename_mapping[col] = expected_name
-                logger.debug(f"Normalizing column name: '{col}' -> '{expected_name}'")
+        else:
+            continue
+
+        if col != expected_name:
+            if expected_name in claimed:
+                logger.warning(
+                    f"Skipping normalization of '{col}' -> '{expected_name}': "
+                    f"target column name is already present"
+                )
+                continue
+            rename_mapping[col] = expected_name
+            claimed.add(expected_name)
+            logger.debug(f"Normalizing column name: '{col}' -> '{expected_name}'")
 
     if rename_mapping:
         logger.info(f"Normalized {len(rename_mapping)} column names: {rename_mapping}")
@@ -581,16 +606,9 @@ class ExcelParser:
 
     def _parse_employee_row(self, row: pd.Series) -> Employee:
         """Parse a single employee row."""
-        # Extract historical ratings
-        history = []
-        if pd.notna(row.get("2023 Completed Performance Rating")):
-            history.append(
-                HistoricalRating(year=2023, rating=str(row["2023 Completed Performance Rating"]))
-            )
-        if pd.notna(row.get("2024 Completed Performance Rating")):
-            history.append(
-                HistoricalRating(year=2024, rating=str(row["2024 Completed Performance Rating"]))
-            )
+        # Extract historical ratings from every "<year> Completed Performance Rating"
+        # column present, so new review cycles are picked up without a code change.
+        history = self._parse_ratings_history(row)
 
         # Get performance and potential (handle different possible column names)
         performance_col = self._find_column(
@@ -792,6 +810,32 @@ class ExcelParser:
         )
 
         return employee
+
+    def _parse_ratings_history(self, row: pd.Series) -> list[HistoricalRating]:
+        """
+        Collect historical performance ratings from all year-prefixed columns.
+
+        Any column named "<4-digit year> Completed Performance Rating" contributes an
+        entry. Results are sorted oldest-first so the timeline renders in order.
+
+        Returns:
+            List of HistoricalRating, ascending by year. Empty if the row has none.
+        """
+        history = []
+        for column in row.index:
+            match = HISTORICAL_RATING_PATTERN.match(str(column).strip())
+            if not match:
+                continue
+            value = row[column]
+            if not pd.notna(value):
+                continue
+            rating = str(value).strip()
+            if not rating:
+                continue
+            history.append(HistoricalRating(year=int(match.group(1)), rating=rating))
+
+        history.sort(key=lambda entry: entry.year)
+        return history
 
     def _find_column(self, row: pd.Series, possible_names: list[str]) -> str | None:
         """

--- a/backend/src/ninebox/services/excel_parser.py
+++ b/backend/src/ninebox/services/excel_parser.py
@@ -823,6 +823,9 @@ class ExcelParser:
         parallel to the current one depending on how the file was assembled, so
         guessing would produce confident but wrong movement flags.
 
+        Within this column the meaning is unambiguous, so both a bare number (5)
+        and a labelled box ("5. Core Talent") are accepted.
+
         Returns:
             Grid position 1-9, or None if absent or not a valid position.
         """
@@ -833,8 +836,12 @@ class ExcelParser:
         try:
             position = int(cast("float", value))
         except (ValueError, TypeError):
-            self.defaulted_fields["Prior Calibration 9-Box Label (Invalid)"] += 1
-            return None
+            leading_digits = re.match(r"\s*(\d+)", str(value))
+            if not leading_digits:
+                logger.warning(f"Prior calibration position '{value}' is not a number, ignoring")
+                self.defaulted_fields["Prior Calibration 9-Box Label (Invalid)"] += 1
+                return None
+            position = int(leading_digits.group(1))
 
         if not 1 <= position <= 9:
             logger.warning(f"Prior calibration position '{value}' out of range 1-9, ignoring")
@@ -853,7 +860,10 @@ class ExcelParser:
         Returns:
             List of HistoricalRating, ascending by year. Empty if the row has none.
         """
-        history = []
+        # Keyed by year so case or spacing variants of the same header
+        # ("2023 Completed..." and "2023 completed...") cannot yield two entries
+        # for one year. First non-empty value wins.
+        by_year: dict[int, str] = {}
         for column in row.index:
             match = HISTORICAL_RATING_PATTERN.match(str(column).strip())
             if not match:
@@ -864,10 +874,13 @@ class ExcelParser:
             rating = str(value).strip()
             if not rating:
                 continue
-            history.append(HistoricalRating(year=int(match.group(1)), rating=rating))
+            year = int(match.group(1))
+            if year in by_year:
+                logger.debug(f"Duplicate history column for {year}, keeping the first value")
+                continue
+            by_year[year] = rating
 
-        history.sort(key=lambda entry: entry.year)
-        return history
+        return [HistoricalRating(year=year, rating=by_year[year]) for year in sorted(by_year)]
 
     def _find_column(self, row: pd.Series, possible_names: list[str]) -> str | None:
         """

--- a/backend/src/ninebox/services/excel_parser.py
+++ b/backend/src/ninebox/services/excel_parser.py
@@ -65,6 +65,7 @@ def normalize_column_names(df: pd.DataFrame) -> pd.DataFrame:
         "time in job profile": "Time in Job Profile",
         "fy25 talent indicator": "FY25 Talent Indicator",
         "talent indicator": "Talent Indicator",
+        "prior calibration 9-box label": "Prior Calibration 9-Box Label",
         "development focus": "Development Focus",
         "development action": "Development Action",
         "notes": "Notes",
@@ -783,6 +784,7 @@ class ExcelParser:
             performance=performance,
             potential=potential,
             grid_position=grid_position,
+            prior_grid_position=self._parse_prior_grid_position(row),
             talent_indicator=str(
                 row.get("FY25 Talent Indicator", row.get("Talent Indicator", ""))
             ).strip()
@@ -810,6 +812,36 @@ class ExcelParser:
         )
 
         return employee
+
+    def _parse_prior_grid_position(self, row: pd.Series) -> int | None:
+        """
+        Read the previous calibration's 9-box position from the row.
+
+        Only the explicit "Prior Calibration 9-Box Label" column is used. Talent
+        indicator labels are deliberately not inferred from: a column like
+        "FY25 Talent Indicator" may hold an assessment that is older, newer, or
+        parallel to the current one depending on how the file was assembled, so
+        guessing would produce confident but wrong movement flags.
+
+        Returns:
+            Grid position 1-9, or None if absent or not a valid position.
+        """
+        value = row.get("Prior Calibration 9-Box Label")
+        if not pd.notna(value):
+            return None
+
+        try:
+            position = int(cast("float", value))
+        except (ValueError, TypeError):
+            self.defaulted_fields["Prior Calibration 9-Box Label (Invalid)"] += 1
+            return None
+
+        if not 1 <= position <= 9:
+            logger.warning(f"Prior calibration position '{value}' out of range 1-9, ignoring")
+            self.defaulted_fields["Prior Calibration 9-Box Label (Invalid)"] += 1
+            return None
+
+        return position
 
     def _parse_ratings_history(self, row: pd.Series) -> list[HistoricalRating]:
         """

--- a/backend/src/ninebox/services/sample_data_generator.py
+++ b/backend/src/ninebox/services/sample_data_generator.py
@@ -251,20 +251,27 @@ def get_column_schema() -> list[ColumnMetadata]:
             example="Jennifer Lee",
             used_for="Filter for viewing by executive leadership",
         ),
-        # Historical Rating Columns
+        # Historical Rating Columns - any "<year> Completed Performance Rating" column
+        # is recognized, so the two most recent completed cycles are shown as examples.
         ColumnMetadata(
-            name="2023 Completed Performance Rating",
+            name=f"{date.today().year - 2} Completed Performance Rating",
             data_type="string",
-            description="Performance rating from 2023 review cycle",
+            description=(
+                "Performance rating from a completed review cycle. Any column named "
+                "'<4-digit year> Completed Performance Rating' is imported."
+            ),
             required=False,
             category=ColumnCategory.HISTORY,
             example="High",
             used_for="Displayed in employee timeline to show rating trends",
         ),
         ColumnMetadata(
-            name="2024 Completed Performance Rating",
+            name=f"{date.today().year - 1} Completed Performance Rating",
             data_type="string",
-            description="Performance rating from 2024 review cycle",
+            description=(
+                "Performance rating from a completed review cycle. Any column named "
+                "'<4-digit year> Completed Performance Rating' is imported."
+            ),
             required=False,
             category=ColumnCategory.HISTORY,
             example="Medium",
@@ -674,14 +681,18 @@ class PerformanceHistoryGenerator:
     - Variance in ratings (some improve, some decline, some stable)
     - Valid rating values: "Low", "Solid", "Strong", "Leading"
 
+    Years are the three review cycles completed before the current one, derived from
+    today's date rather than hardcoded, so sample data never goes stale.
+
     Example:
         >>> generator = PerformanceHistoryGenerator(seed=42)
         >>> hire_date = date(2020, 1, 1)
         >>> history = generator.generate_history(1, hire_date, "Strong")
         >>> len(history)
         3
-        >>> {h["year"] for h in history}
-        {2023, 2024, 2025}
+        >>> this_year = date.today().year
+        >>> {h["year"] for h in history} == {this_year - 3, this_year - 2, this_year - 1}
+        True
     """
 
     def __init__(self, seed: int | None = None) -> None:
@@ -727,7 +738,11 @@ class PerformanceHistoryGenerator:
         # 80% have complete history, 20% have gaps
         has_complete_history = self.rng.random() < 0.8
 
-        years = [2023, 2024, 2025][-max_years:]
+        # The completed cycles preceding the current one, e.g. 2023/2024/2025 in 2026
+        latest_completed_year = today.year - 1
+        years = [latest_completed_year - 2, latest_completed_year - 1, latest_completed_year][
+            -max_years:
+        ]
 
         if not has_complete_history and max_years > 1:
             # Remove random year(s)
@@ -737,8 +752,8 @@ class PerformanceHistoryGenerator:
 
         # Generate ratings with variance
         for year in years:
-            if year == 2025:
-                # Current year uses current rating
+            if year == latest_completed_year:
+                # Most recent completed cycle tracks the current rating
                 rating = current_rating
             else:
                 # Historical ratings vary

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,7 @@ def create_test_employee(
     potential: PotentialLevel = PotentialLevel.MEDIUM,
     flags: list[str] | None = None,
     grid_position: int = 5,
+    prior_grid_position: int | None = None,
 ) -> Employee:
     """Create a minimal Employee for testing with all required fields.
 
@@ -62,6 +63,7 @@ def create_test_employee(
         performance=performance,
         potential=potential,
         grid_position=grid_position,
+        prior_grid_position=prior_grid_position,
         talent_indicator="Solid Contributor",
         flags=flags,
     )
@@ -74,6 +76,7 @@ def create_simple_test_employee(
     potential: PotentialLevel = PotentialLevel.MEDIUM,
     flags: list[str] | None = None,
     grid_position: int = 5,
+    prior_grid_position: int | None = None,
 ) -> Employee:
     """Create a minimal Employee for testing with all required fields.
 
@@ -117,6 +120,7 @@ def create_simple_test_employee(
         performance=performance,
         potential=potential,
         grid_position=grid_position,
+        prior_grid_position=prior_grid_position,
         talent_indicator="Solid Contributor",
         flags=flags,
     )
@@ -176,7 +180,9 @@ def test_db_path(request: pytest.FixtureRequest) -> Generator[str, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def setup_test_db(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+def setup_test_db(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Generator[None, None, None]:
     """Enhanced database isolation for VSCode test execution.
 
     This fixture provides COMPLETE database isolation when VSCode runs tests
@@ -193,6 +199,7 @@ def setup_test_db(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatc
 
     # Create unique temporary directory for THIS test
     import tempfile  # noqa: PLC0415
+
     test_temp_dir = tempfile.mkdtemp(prefix=f"test_{test_id}_", suffix="_ninebox")
     test_db_path = Path(test_temp_dir) / "ninebox.db"
 
@@ -319,6 +326,7 @@ def setup_test_db(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatc
     # Clean up temp directory
     try:
         import shutil  # noqa: PLC0415
+
         if Path(test_temp_dir).exists():
             shutil.rmtree(test_temp_dir)
     except Exception:

--- a/backend/tests/unit/services/test_employee_service.py
+++ b/backend/tests/unit/services/test_employee_service.py
@@ -7,8 +7,10 @@ from ninebox.services.employee_service import (
     EmployeeService,
     PerformanceTier,
     get_tier_from_historical_rating,
+    get_axis_distance,
     get_tier_from_position,
     is_big_mover,
+    is_medium_mover,
     is_tier_crossing,
 )
 from tests.conftest import create_simple_test_employee
@@ -53,7 +55,9 @@ def test_filter_employees_when_by_manager_then_filters_correctly(
     """Test filtering by manager."""
     # Find a manager that exists in sample data
     test_manager = (
-        sample_employees[10].direct_manager if len(sample_employees) > 10 else sample_employees[0].direct_manager
+        sample_employees[10].direct_manager
+        if len(sample_employees) > 10
+        else sample_employees[0].direct_manager
     )
     expected_count = sum(1 for emp in sample_employees if emp.direct_manager == test_manager)
 
@@ -89,7 +93,9 @@ def test_filter_employees_when_combined_filters_then_applies_and_logic(
     # Use the manager of the first MT4 employee
     test_manager = mt4_employees[0].direct_manager
     expected_count = sum(
-        1 for emp in sample_employees if emp.job_level == "MT4" and emp.direct_manager == test_manager
+        1
+        for emp in sample_employees
+        if emp.job_level == "MT4" and emp.direct_manager == test_manager
     )
 
     filtered = employee_service.filter_employees(
@@ -182,7 +188,9 @@ def test_get_filter_options_when_called_then_returns_correct_options(
     actual_levels = {emp.job_level for emp in sample_employees}
     actual_functions = {emp.job_function for emp in sample_employees}
     actual_managers = {
-        emp.direct_manager for emp in sample_employees if emp.direct_manager and emp.direct_manager != "None"
+        emp.direct_manager
+        for emp in sample_employees
+        if emp.direct_manager and emp.direct_manager != "None"
     }
 
     # Check levels - should match what's in sample data
@@ -508,3 +516,86 @@ def test_is_big_mover_when_multiple_historical_ratings_then_uses_most_recent() -
 
     # Should use 2023 "Low" rating → Big mover (LOW to HIGH)
     assert is_big_mover(employee) is True
+
+
+# Calibration-to-calibration movement
+
+
+def test_is_big_mover_when_prior_calibration_crossed_tiers_then_true() -> None:
+    """A Low->High swing since the last calibration is a big move."""
+    employee = create_simple_test_employee(
+        grid_position=8,  # Growth [M,H] - High tier
+        prior_grid_position=3,  # Expert [H,L] - Low tier
+    )
+
+    assert is_big_mover(employee) is True
+
+
+def test_is_big_mover_when_prior_calibration_within_tiers_then_false() -> None:
+    """Movement that stays out of the Low<->High crossing is not a big move."""
+    employee = create_simple_test_employee(
+        grid_position=9,  # Star [H,H] - High tier
+        prior_grid_position=5,  # Core [M,M] - Middle tier
+    )
+
+    assert is_big_mover(employee) is False
+
+
+def test_is_big_mover_when_no_prior_calibration_then_falls_back_to_other_checks() -> None:
+    """Employees new to the roster have no prior position and must not error."""
+    employee = create_simple_test_employee(grid_position=9, prior_grid_position=None)
+
+    assert is_big_mover(employee) is False
+
+
+def test_get_axis_distance_when_diagonal_then_counts_both_axes() -> None:
+    """A diagonal move counts one step per axis, not one step overall."""
+    assert get_axis_distance(5, 9) == 2  # Core [M,M] -> Star [H,H]
+    assert get_axis_distance(1, 9) == 4  # Underperformer [L,L] -> Star [H,H]
+    assert get_axis_distance(5, 6) == 1  # Core [M,M] -> High Impact [H,M]
+    assert get_axis_distance(5, 5) == 0
+
+
+def test_get_axis_distance_when_position_out_of_range_then_raises() -> None:
+    """Invalid positions are rejected rather than silently scored."""
+    with pytest.raises(ValueError, match="Invalid grid position"):
+        get_axis_distance(0, 5)
+    with pytest.raises(ValueError, match="Invalid grid position"):
+        get_axis_distance(5, 10)
+
+
+def test_is_medium_mover_when_two_axis_steps_since_calibration_then_true() -> None:
+    """Core -> Star moves on both axes without crossing Low/High tiers."""
+    employee = create_simple_test_employee(grid_position=9, prior_grid_position=5)
+
+    assert is_medium_mover(employee) is True
+
+
+def test_is_medium_mover_when_single_axis_step_then_false() -> None:
+    """A one-step nudge is normal calibration drift, not a notable move."""
+    employee = create_simple_test_employee(grid_position=6, prior_grid_position=5)
+
+    assert is_medium_mover(employee) is False
+
+
+def test_is_medium_mover_when_also_big_mover_then_false() -> None:
+    """The two flags are mutually exclusive so filters partition cleanly."""
+    employee = create_simple_test_employee(grid_position=8, prior_grid_position=3)
+
+    assert is_big_mover(employee) is True
+    assert is_medium_mover(employee) is False
+
+
+def test_is_medium_mover_when_in_session_move_then_true() -> None:
+    """Two-axis drags during the meeting count the same as calibration moves."""
+    current = create_simple_test_employee(grid_position=9)
+    original = create_simple_test_employee(grid_position=5)
+
+    assert is_medium_mover(current, original) is True
+
+
+def test_is_medium_mover_when_no_comparison_available_then_false() -> None:
+    """No prior position and no in-session move means nothing to compare."""
+    employee = create_simple_test_employee(grid_position=9)
+
+    assert is_medium_mover(employee) is False

--- a/backend/tests/unit/services/test_employee_service.py
+++ b/backend/tests/unit/services/test_employee_service.py
@@ -8,6 +8,7 @@ from ninebox.services.employee_service import (
     PerformanceTier,
     get_tier_from_historical_rating,
     get_axis_distance,
+    get_most_recent_prior_year_rating,
     get_tier_from_position,
     is_big_mover,
     is_medium_mover,
@@ -599,3 +600,62 @@ def test_is_medium_mover_when_no_comparison_available_then_false() -> None:
     employee = create_simple_test_employee(grid_position=9)
 
     assert is_medium_mover(employee) is False
+
+
+# Current-cycle ratings must not be mistaken for prior-year history
+
+
+def test_get_most_recent_prior_year_rating_when_current_year_present_then_excluded() -> None:
+    """The current cycle's own rating is not history to compare against."""
+    from datetime import date
+
+    this_year = date.today().year
+    employee = create_simple_test_employee()
+    employee.ratings_history = [
+        HistoricalRating(year=this_year - 2, rating="Solid"),
+        HistoricalRating(year=this_year - 1, rating="Strong"),
+        HistoricalRating(year=this_year, rating="Leading"),
+    ]
+
+    assert get_most_recent_prior_year_rating(employee) == "Strong"
+
+
+def test_get_most_recent_prior_year_rating_when_only_current_year_then_none() -> None:
+    """Nothing completed means nothing to compare year-over-year."""
+    from datetime import date
+
+    employee = create_simple_test_employee()
+    employee.ratings_history = [HistoricalRating(year=date.today().year, rating="Leading")]
+
+    assert get_most_recent_prior_year_rating(employee) is None
+
+
+def test_get_most_recent_prior_year_rating_when_unordered_then_latest_wins() -> None:
+    """Order in the list must not decide which year counts as most recent."""
+    from datetime import date
+
+    this_year = date.today().year
+    employee = create_simple_test_employee()
+    employee.ratings_history = [
+        HistoricalRating(year=this_year - 1, rating="Strong"),
+        HistoricalRating(year=this_year - 3, rating="Low"),
+    ]
+
+    assert get_most_recent_prior_year_rating(employee) == "Strong"
+
+
+def test_is_big_mover_when_only_current_year_rating_then_not_flagged() -> None:
+    """A current-cycle rating describes the same period as the current box.
+
+    Regression: once history stopped being limited to 2023/2024, a rating for
+    the live year would otherwise be compared against the position it describes
+    and report movement that never happened.
+    """
+    from datetime import date
+
+    employee = create_simple_test_employee(grid_position=4)  # Low tier
+    employee.ratings_history = [
+        HistoricalRating(year=date.today().year, rating="Leading")  # High tier
+    ]
+
+    assert is_big_mover(employee) is False

--- a/backend/tests/unit/services/test_excel_exporter.py
+++ b/backend/tests/unit/services/test_excel_exporter.py
@@ -979,7 +979,7 @@ def test_export_when_no_history_then_no_history_columns_and_trailing_intact(
         sheet = workbook.worksheets[1]
         headers = _header_map(sheet)
         assert not [h for h in headers if "Completed Performance Rating" in str(h)]
-        assert headers["Development Focus"] == headers["FY25 Talent Indicator"] + 1
+        assert headers["Development Focus"] == headers["Prior Calibration 9-Box Label"] + 1
     finally:
         workbook.close()
 
@@ -1000,3 +1000,19 @@ def test_export_then_reimport_round_trips_history_for_any_year(
         (2025, "Strong"),
         (2026, "Leading"),
     ]
+
+
+def test_export_when_prior_position_set_then_round_trips(
+    excel_exporter: ExcelExporter, tmp_path: Path
+) -> None:
+    """The prior calibration position survives an export/re-import cycle."""
+    from ninebox.services.excel_parser import ExcelParser
+
+    output_path = tmp_path / "prior_round_trip.xlsx"
+    employee = _employee_with_history(1, [(2025, "Strong")])
+    employee.prior_grid_position = 4
+
+    excel_exporter.export("", [employee], output_path)
+    reparsed = ExcelParser().parse(output_path)
+
+    assert reparsed.employees[0].prior_grid_position == 4

--- a/backend/tests/unit/services/test_excel_exporter.py
+++ b/backend/tests/unit/services/test_excel_exporter.py
@@ -33,18 +33,15 @@ def cleanup_openpyxl_state() -> Generator[None, None, None]:
 
     # 2. Clear any cached openpyxl modules that might hold state
     # This ensures fresh imports get clean module state
-    openpyxl_modules = [
-        name for name in sys.modules.keys()
-        if name.startswith('openpyxl')
-    ]
+    openpyxl_modules = [name for name in sys.modules.keys() if name.startswith("openpyxl")]
 
     # Store references to avoid module re-import issues during iteration
     modules_to_clear = []
     for name in openpyxl_modules:
         module = sys.modules.get(name)
-        if module and hasattr(module, '__dict__'):
+        if module and hasattr(module, "__dict__"):
             # Clear module-level caches if they exist
-            if hasattr(module, '_cache'):
+            if hasattr(module, "_cache"):
                 try:
                     module._cache.clear()
                 except (AttributeError, TypeError):
@@ -64,8 +61,8 @@ def cleanup_openpyxl_state() -> Generator[None, None, None]:
     # 2. Clear openpyxl module caches again
     for name in openpyxl_modules:
         module = sys.modules.get(name)
-        if module and hasattr(module, '__dict__'):
-            if hasattr(module, '_cache'):
+        if module and hasattr(module, "__dict__"):
+            if hasattr(module, "_cache"):
                 try:
                     module._cache.clear()
                 except (AttributeError, TypeError):
@@ -881,3 +878,125 @@ def test_export_when_current_values_updated_then_main_columns_have_new_values(
     assert sheet.cell(2, perf_col).value == "Low"
     assert sheet.cell(2, pot_col).value == "High"
     workbook.close()
+
+
+def _employee_with_history(employee_id: int, history: list[tuple[int, str]]) -> Employee:
+    """Build a minimal employee carrying the given (year, rating) history."""
+    from datetime import date
+
+    from ninebox.models.employee import HistoricalRating
+
+    return Employee(
+        employee_id=employee_id,
+        name=f"Employee {employee_id}",
+        business_title="Engineer",
+        job_title="Engineer",
+        job_profile="Engineering-USA",
+        job_level="MT4",
+        job_function="Engineering",
+        location="USA",
+        direct_manager="Bob Manager",
+        hire_date=date(2020, 1, 15),
+        tenure_category="3-5 years",
+        time_in_job_profile="2 years",
+        performance=PerformanceLevel.HIGH,
+        potential=PotentialLevel.HIGH,
+        grid_position=9,
+        talent_indicator="Top Talent",
+        ratings_history=[HistoricalRating(year=y, rating=r) for y, r in history],
+    )
+
+
+def _header_map(sheet) -> dict[str, int]:  # type: ignore[no-untyped-def]
+    return {
+        sheet.cell(1, col).value: col
+        for col in range(1, sheet.max_column + 1)
+        if sheet.cell(1, col).value
+    }
+
+
+def test_export_when_history_has_arbitrary_years_then_writes_a_column_per_year(
+    excel_exporter: ExcelExporter, tmp_path: Path
+) -> None:
+    """Export must emit history columns for whatever years the data contains."""
+    output_path = tmp_path / "history_years.xlsx"
+    employees = [_employee_with_history(1, [(2024, "Solid"), (2025, "Strong"), (2026, "Leading")])]
+
+    excel_exporter.export("", employees, output_path)
+
+    workbook = openpyxl.load_workbook(output_path)
+    try:
+        sheet = workbook.worksheets[1]
+        headers = _header_map(sheet)
+        for year, rating in [(2024, "Solid"), (2025, "Strong"), (2026, "Leading")]:
+            column = headers[f"{year} Completed Performance Rating"]
+            assert sheet.cell(2, column).value == rating
+    finally:
+        workbook.close()
+
+
+def test_export_when_history_years_differ_across_employees_then_union_is_written(
+    excel_exporter: ExcelExporter, tmp_path: Path
+) -> None:
+    """Columns cover the union of years, with blanks where an employee has no rating."""
+    output_path = tmp_path / "history_union.xlsx"
+    employees = [
+        _employee_with_history(1, [(2023, "Solid")]),
+        _employee_with_history(2, [(2026, "Leading")]),
+    ]
+
+    excel_exporter.export("", employees, output_path)
+
+    workbook = openpyxl.load_workbook(output_path)
+    try:
+        sheet = workbook.worksheets[1]
+        headers = _header_map(sheet)
+        col_2023 = headers["2023 Completed Performance Rating"]
+        col_2026 = headers["2026 Completed Performance Rating"]
+
+        assert sheet.cell(2, col_2023).value == "Solid"
+        assert sheet.cell(2, col_2026).value is None
+        assert sheet.cell(3, col_2023).value is None
+        assert sheet.cell(3, col_2026).value == "Leading"
+
+        # Trailing columns must shift to sit after the history block
+        assert headers["Development Focus"] > col_2026
+        assert headers["Promotion Readiness"] > headers["Notes"]
+    finally:
+        workbook.close()
+
+
+def test_export_when_no_history_then_no_history_columns_and_trailing_intact(
+    excel_exporter: ExcelExporter, tmp_path: Path
+) -> None:
+    """With no history at all the sheet still has well-formed trailing columns."""
+    output_path = tmp_path / "no_history.xlsx"
+
+    excel_exporter.export("", [_employee_with_history(1, [])], output_path)
+
+    workbook = openpyxl.load_workbook(output_path)
+    try:
+        sheet = workbook.worksheets[1]
+        headers = _header_map(sheet)
+        assert not [h for h in headers if "Completed Performance Rating" in str(h)]
+        assert headers["Development Focus"] == headers["FY25 Talent Indicator"] + 1
+    finally:
+        workbook.close()
+
+
+def test_export_then_reimport_round_trips_history_for_any_year(
+    excel_exporter: ExcelExporter, tmp_path: Path
+) -> None:
+    """Parser and exporter agree on the history schema for non-2023/2024 years."""
+    from ninebox.services.excel_parser import ExcelParser
+
+    output_path = tmp_path / "round_trip.xlsx"
+    employees = [_employee_with_history(1, [(2025, "Strong"), (2026, "Leading")])]
+
+    excel_exporter.export("", employees, output_path)
+    reparsed = ExcelParser().parse(output_path)
+
+    assert [(r.year, r.rating) for r in reparsed.employees[0].ratings_history] == [
+        (2025, "Strong"),
+        (2026, "Leading"),
+    ]

--- a/backend/tests/unit/services/test_excel_parser.py
+++ b/backend/tests/unit/services/test_excel_parser.py
@@ -368,3 +368,96 @@ def test_parse_when_no_donut_data_then_donut_fields_none(tmp_path: Path) -> None
     assert emp.donut_performance is None
     assert emp.donut_potential is None
     assert emp.donut_notes is None
+
+
+def _write_history_sheet(path: Path, history_headers: list[str], values: list[str | None]) -> None:
+    """Write a minimal one-employee sheet with the given history columns."""
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    assert sheet is not None
+    sheet.title = "Employee Data"
+
+    base = [
+        "Employee ID",
+        "Worker",
+        "Business Title",
+        "Job Level - Primary Position",
+        "Aug 2025 Talent Assessment Performance",
+        "Aug 2025  Talent Assessment Potential",
+    ]
+    for col, header in enumerate(base + history_headers, start=1):
+        sheet.cell(1, col, header)
+    for col, value in enumerate(
+        [1, "Test Employee", "Engineer", "MT4", "High", "High", *values], start=1
+    ):
+        sheet.cell(2, col, value)
+
+    workbook.save(path)
+    workbook.close()
+
+
+def test_parse_when_history_columns_for_any_year_then_all_are_imported(tmp_path: Path) -> None:
+    """Review years beyond 2023/2024 must be imported, not silently dropped."""
+    test_file = tmp_path / "any_year_history.xlsx"
+    _write_history_sheet(
+        test_file,
+        [
+            "2022 Completed Performance Rating",
+            "2025 Completed Performance Rating",
+            "2026 Completed Performance Rating",
+        ],
+        ["Solid", "Strong", "Leading"],
+    )
+
+    result = ExcelParser().parse(test_file)
+
+    assert [(r.year, r.rating) for r in result.employees[0].ratings_history] == [
+        (2022, "Solid"),
+        (2025, "Strong"),
+        (2026, "Leading"),
+    ]
+
+
+def test_parse_when_history_columns_out_of_order_then_sorted_ascending(tmp_path: Path) -> None:
+    """History is returned oldest-first regardless of column order in the file."""
+    test_file = tmp_path / "unordered_history.xlsx"
+    _write_history_sheet(
+        test_file,
+        [
+            "2026 Completed Performance Rating",
+            "2023 Completed Performance Rating",
+            "2025 Completed Performance Rating",
+        ],
+        ["Leading", "Solid", "Strong"],
+    )
+
+    result = ExcelParser().parse(test_file)
+
+    assert [r.year for r in result.employees[0].ratings_history] == [2023, 2025, 2026]
+
+
+def test_parse_when_history_header_lowercase_then_still_imported(tmp_path: Path) -> None:
+    """Year-prefixed history headers are matched case-insensitively."""
+    test_file = tmp_path / "lowercase_history.xlsx"
+    _write_history_sheet(test_file, ["2026 completed performance rating"], ["Leading"])
+
+    result = ExcelParser().parse(test_file)
+
+    assert [(r.year, r.rating) for r in result.employees[0].ratings_history] == [(2026, "Leading")]
+
+
+def test_parse_when_history_cell_blank_then_year_omitted(tmp_path: Path) -> None:
+    """Empty history cells produce no timeline entry for that year."""
+    test_file = tmp_path / "blank_history.xlsx"
+    _write_history_sheet(
+        test_file,
+        [
+            "2025 Completed Performance Rating",
+            "2026 Completed Performance Rating",
+        ],
+        [None, "   "],
+    )
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].ratings_history == []

--- a/backend/tests/unit/services/test_excel_parser.py
+++ b/backend/tests/unit/services/test_excel_parser.py
@@ -558,3 +558,48 @@ def test_parse_when_talent_indicator_looks_like_a_box_then_not_used_as_prior(
 
     assert result.employees[0].talent_indicator == "3. Expert Talent"
     assert result.employees[0].prior_grid_position is None
+
+
+def test_parse_when_prior_calibration_is_a_label_then_box_number_extracted(
+    tmp_path: Path,
+) -> None:
+    """Within the explicit column the meaning is unambiguous, so labels work too."""
+    test_file = tmp_path / "labelled_prior.xlsx"
+    _write_prior_position_sheet(test_file, "5. Core Talent")
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].prior_grid_position == 5
+
+
+def test_parse_when_prior_calibration_label_out_of_range_then_none(tmp_path: Path) -> None:
+    """A label whose leading number is not a box is still rejected."""
+    test_file = tmp_path / "bad_label_prior.xlsx"
+    _write_prior_position_sheet(test_file, "12. Not A Box")
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].prior_grid_position is None
+
+
+def test_parse_when_duplicate_year_headers_then_single_history_entry(tmp_path: Path) -> None:
+    """Case variants of one year's header must not produce two entries.
+
+    Header normalization deliberately leaves the second variant alone rather
+    than creating a duplicate DataFrame column, so the dedupe has to happen when
+    history is collected.
+    """
+    test_file = tmp_path / "duplicate_year.xlsx"
+    _write_history_sheet(
+        test_file,
+        [
+            "2023 Completed Performance Rating",
+            "2023 completed performance rating",
+        ],
+        ["Strong", "Leading"],
+    )
+
+    result = ExcelParser().parse(test_file)
+
+    history = result.employees[0].ratings_history
+    assert [(r.year, r.rating) for r in history] == [(2023, "Strong")]

--- a/backend/tests/unit/services/test_excel_parser.py
+++ b/backend/tests/unit/services/test_excel_parser.py
@@ -461,3 +461,100 @@ def test_parse_when_history_cell_blank_then_year_omitted(tmp_path: Path) -> None
     result = ExcelParser().parse(test_file)
 
     assert result.employees[0].ratings_history == []
+
+
+def _write_prior_position_sheet(path: Path, value: object) -> None:
+    """Write a one-employee sheet carrying the given prior calibration cell."""
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    assert sheet is not None
+    sheet.title = "Employee Data"
+
+    headers = [
+        "Employee ID",
+        "Worker",
+        "Business Title",
+        "Job Level - Primary Position",
+        "Aug 2025 Talent Assessment Performance",
+        "Aug 2025  Talent Assessment Potential",
+        "Prior Calibration 9-Box Label",
+    ]
+    for col, header in enumerate(headers, start=1):
+        sheet.cell(1, col, header)
+    for col, cell in enumerate(
+        [1, "Test Employee", "Engineer", "MT4", "High", "High", value], start=1
+    ):
+        sheet.cell(2, col, cell)
+
+    workbook.save(path)
+    workbook.close()
+
+
+def test_parse_when_prior_calibration_column_present_then_position_imported(
+    tmp_path: Path,
+) -> None:
+    """The previous calibration's box is read for movement comparison."""
+    test_file = tmp_path / "prior_position.xlsx"
+    _write_prior_position_sheet(test_file, 3)
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].prior_grid_position == 3
+
+
+def test_parse_when_prior_calibration_column_absent_then_none(tmp_path: Path) -> None:
+    """Files without the column parse fine and simply have no prior position."""
+    test_file = tmp_path / "no_prior.xlsx"
+    _write_history_sheet(test_file, [], [])
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].prior_grid_position is None
+
+
+@pytest.mark.parametrize("value", [0, 10, "Top Talent", ""])
+def test_parse_when_prior_calibration_invalid_then_none(tmp_path: Path, value: object) -> None:
+    """Out-of-range or non-numeric prior positions are ignored, not guessed at."""
+    test_file = tmp_path / "bad_prior.xlsx"
+    _write_prior_position_sheet(test_file, value)
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].prior_grid_position is None
+
+
+def test_parse_when_talent_indicator_looks_like_a_box_then_not_used_as_prior(
+    tmp_path: Path,
+) -> None:
+    """A talent indicator must not be inferred as the prior calibration position.
+
+    The column's meaning varies by source file - it may hold an older, newer or
+    parallel assessment - so guessing would produce confident but wrong flags.
+    """
+    test_file = tmp_path / "indicator_only.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    assert sheet is not None
+    sheet.title = "Employee Data"
+    headers = [
+        "Employee ID",
+        "Worker",
+        "Business Title",
+        "Job Level - Primary Position",
+        "Aug 2025 Talent Assessment Performance",
+        "Aug 2025  Talent Assessment Potential",
+        "FY25 Talent Indicator",
+    ]
+    for col, header in enumerate(headers, start=1):
+        sheet.cell(1, col, header)
+    for col, cell in enumerate(
+        [1, "Test Employee", "Engineer", "MT4", "High", "High", "3. Expert Talent"], start=1
+    ):
+        sheet.cell(2, col, cell)
+    workbook.save(test_file)
+    workbook.close()
+
+    result = ExcelParser().parse(test_file)
+
+    assert result.employees[0].talent_indicator == "3. Expert Talent"
+    assert result.employees[0].prior_grid_position is None

--- a/frontend/src/components/panel/EmployeeDetails.tsx
+++ b/frontend/src/components/panel/EmployeeDetails.tsx
@@ -30,6 +30,7 @@ import {
 import {
   getPositionName,
   getShortPositionLabel,
+  getAxisDistance,
 } from "../../constants/positionLabels";
 import { EmployeeFlags } from "./EmployeeFlags";
 import { EmployeeChangesSummary } from "./EmployeeChangesSummary";
@@ -90,6 +91,11 @@ export const EmployeeDetails: React.FC<EmployeeDetailsProps> = ({
   employee,
 }) => {
   const { t } = useTranslation();
+
+  const priorMoveSteps =
+    employee.prior_grid_position != null
+      ? getAxisDistance(employee.prior_grid_position, employee.grid_position)
+      : 0;
 
   return (
     <Card variant="outlined">
@@ -162,6 +168,28 @@ export const EmployeeDetails: React.FC<EmployeeDetailsProps> = ({
                 {getPositionName(employee.grid_position)}{" "}
                 {getShortPositionLabel(employee.grid_position)}
               </Typography>
+
+              {/* Where they sat at the last calibration, and how far they moved */}
+              {employee.prior_grid_position != null && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block"
+                  sx={{ mt: 0.5 }}
+                  data-testid="prior-calibration-label"
+                >
+                  {t("panel.detailsTab.previousCalibration")}:{" "}
+                  {getPositionName(employee.prior_grid_position)}{" "}
+                  {getShortPositionLabel(employee.prior_grid_position)}
+                  {" — "}
+                  {priorMoveSteps === 0
+                    ? t("panel.detailsTab.movedNoChange")
+                    : t("panel.detailsTab.movedSteps", {
+                        count: priorMoveSteps,
+                        steps: priorMoveSteps,
+                      })}
+                </Typography>
+              )}
             </Box>
 
             {/* Performance and Potential Chips */}

--- a/frontend/src/components/panel/EmployeeFlags.tsx
+++ b/frontend/src/components/panel/EmployeeFlags.tsx
@@ -23,6 +23,8 @@ import {
   getAllFlags,
   getFlagDisplayName,
   getFlagColor,
+  isDerivedFlag,
+  toPersistableFlags,
 } from "../../constants/flags";
 
 interface EmployeeFlagsProps {
@@ -37,10 +39,14 @@ export const EmployeeFlags: React.FC<EmployeeFlagsProps> = ({ employee }) => {
   // Get current flags (default to empty array)
   const currentFlags = employee.flags || [];
 
-  // Get available flags (flags not already set)
+  // Movement flags are computed by the backend, so they are shown but cannot be
+  // added or removed by hand, and are never included in an update payload.
+  const assignedFlags = toPersistableFlags(currentFlags);
+
+  // Get available flags (user-assignable flags not already set)
   const allFlags = getAllFlags();
   const availableFlags = allFlags.filter(
-    (flag) => !currentFlags.includes(flag.key)
+    (flag) => !isDerivedFlag(flag.key) && !currentFlags.includes(flag.key)
   );
 
   const handleAddFlag = async (
@@ -50,7 +56,7 @@ export const EmployeeFlags: React.FC<EmployeeFlagsProps> = ({ employee }) => {
     if (!flagKey) return;
 
     // Add flag to employee
-    const updatedFlags = [...currentFlags, flagKey];
+    const updatedFlags = [...assignedFlags, flagKey];
     await updateEmployee(employee.employee_id, {
       flags: updatedFlags,
     });
@@ -61,7 +67,7 @@ export const EmployeeFlags: React.FC<EmployeeFlagsProps> = ({ employee }) => {
 
   const handleRemoveFlag = async (flagKey: string) => {
     // Remove flag from employee
-    const updatedFlags = currentFlags.filter((f) => f !== flagKey);
+    const updatedFlags = assignedFlags.filter((f) => f !== flagKey);
     await updateEmployee(employee.employee_id, {
       flags: updatedFlags,
     });
@@ -76,7 +82,11 @@ export const EmployeeFlags: React.FC<EmployeeFlagsProps> = ({ employee }) => {
             <Chip
               key={flagKey}
               label={getFlagDisplayName(flagKey)}
-              onDelete={() => handleRemoveFlag(flagKey)}
+              onDelete={
+                isDerivedFlag(flagKey)
+                  ? undefined
+                  : () => handleRemoveFlag(flagKey)
+              }
               sx={{
                 backgroundColor: getFlagColor(flagKey),
                 color: "white",

--- a/frontend/src/components/panel/RatingsTimeline.tsx
+++ b/frontend/src/components/panel/RatingsTimeline.tsx
@@ -38,12 +38,11 @@ export const RatingsTimeline: React.FC<RatingsTimelineProps> = ({
   );
 
   // The current assessment is the live calibration, so label it with the current
-  // year rather than a hardcoded one. Stay ahead of the newest completed cycle so
-  // the timeline never shows a duplicate or out-of-order year.
-  const currentYear = Math.max(
-    new Date().getFullYear(),
-    (sortedRatings[0]?.year ?? 0) + 1
-  );
+  // year rather than a hardcoded one. Deliberately not clamped above the newest
+  // history year: a rating for this year can legitimately coexist with the
+  // current assessment (an annual rating and a calibration are different
+  // things), and inventing a future year to separate them reads as a bug.
+  const currentYear = new Date().getFullYear();
 
   return (
     <Card variant="outlined">

--- a/frontend/src/components/panel/RatingsTimeline.tsx
+++ b/frontend/src/components/panel/RatingsTimeline.tsx
@@ -37,6 +37,14 @@ export const RatingsTimeline: React.FC<RatingsTimelineProps> = ({
     (a, b) => b.year - a.year
   );
 
+  // The current assessment is the live calibration, so label it with the current
+  // year rather than a hardcoded one. Stay ahead of the newest completed cycle so
+  // the timeline never shows a duplicate or out-of-order year.
+  const currentYear = Math.max(
+    new Date().getFullYear(),
+    (sortedRatings[0]?.year ?? 0) + 1
+  );
+
   return (
     <Card variant="outlined">
       <CardContent>
@@ -45,7 +53,7 @@ export const RatingsTimeline: React.FC<RatingsTimelineProps> = ({
         </Typography>
 
         <Timeline sx={{ p: 0, m: 0, pl: 0 }}>
-          {/* Current Year (2025) */}
+          {/* Current assessment */}
           <TimelineItem sx={{ "&::before": { flex: 0, padding: 0 } }}>
             <TimelineSeparator>
               <TimelineDot color="success" />
@@ -53,7 +61,7 @@ export const RatingsTimeline: React.FC<RatingsTimelineProps> = ({
             </TimelineSeparator>
             <TimelineContent sx={{ py: 0, px: 2 }}>
               <Typography variant="body2" fontWeight="medium">
-                {t("panel.detailsTab.currentYear", { year: 2025 })}
+                {t("panel.detailsTab.currentYear", { year: currentYear })}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 {t("panel.detailsTab.performance")}: {employee.performance}

--- a/frontend/src/components/panel/__tests__/EmployeeFlagsDerived.test.tsx
+++ b/frontend/src/components/panel/__tests__/EmployeeFlagsDerived.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  isDerivedFlag,
+  toPersistableFlags,
+  getAllFlags,
+} from "../../../constants/flags";
+
+describe("derived movement flags", () => {
+  it("marks movement flags as derived and others as user-assignable", () => {
+    expect(isDerivedFlag("big_mover")).toBe(true);
+    expect(isDerivedFlag("medium_mover")).toBe(true);
+    expect(isDerivedFlag("flight_risk")).toBe(false);
+  });
+
+  it("strips derived flags from an update payload", () => {
+    // Regression: the API rejects derived flags with a 422, so adding any flag
+    // to a big mover used to fail outright.
+    expect(
+      toPersistableFlags(["big_mover", "flight_risk", "medium_mover"])
+    ).toEqual(["flight_risk"]);
+  });
+
+  it("leaves user-assigned flags untouched", () => {
+    expect(toPersistableFlags(["flight_risk", "pip"])).toEqual([
+      "flight_risk",
+      "pip",
+    ]);
+  });
+
+  it("registers medium_mover so it appears as a filter option", () => {
+    expect(getAllFlags().map((f) => f.key)).toContain("medium_mover");
+  });
+});

--- a/frontend/src/components/panel/__tests__/RatingsTimeline.test.tsx
+++ b/frontend/src/components/panel/__tests__/RatingsTimeline.test.tsx
@@ -42,23 +42,28 @@ describe("RatingsTimeline", () => {
     expect(performanceText).toBeInTheDocument();
   });
 
-  it("labels current assessment ahead of the newest history year", () => {
-    // Guards against a stale hardcoded year: if history already reaches the
-    // current calendar year, the current assessment must still sort above it.
-    const nextYear = new Date().getFullYear() + 1;
+  it("labels the current assessment with the current year, never a future one", () => {
+    // A rating for this year can coexist with the current assessment; the label
+    // must still read as today's year rather than being pushed into the future.
+    const thisYear = new Date().getFullYear();
     const employee = createMockEmployee({
-      ratings_history: [{ year: nextYear, rating: "Leading" }],
+      ratings_history: [{ year: thisYear, rating: "Leading" }],
     });
 
     render(<RatingsTimeline employee={employee} />);
 
     expect(
       screen.getByText(
-        getTranslatedText("panel.detailsTab.currentYear", {
-          year: nextYear + 1,
-        })
+        getTranslatedText("panel.detailsTab.currentYear", { year: thisYear })
       )
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        getTranslatedText("panel.detailsTab.currentYear", {
+          year: thisYear + 1,
+        })
+      )
+    ).not.toBeInTheDocument();
   });
 
   it("displays historical ratings sorted by year descending", () => {

--- a/frontend/src/components/panel/__tests__/RatingsTimeline.test.tsx
+++ b/frontend/src/components/panel/__tests__/RatingsTimeline.test.tsx
@@ -32,12 +32,33 @@ describe("RatingsTimeline", () => {
 
     expect(
       screen.getByText(
-        getTranslatedText("panel.detailsTab.currentYear", { year: 2025 })
+        getTranslatedText("panel.detailsTab.currentYear", {
+          year: new Date().getFullYear(),
+        })
       )
     ).toBeInTheDocument();
     // Check for performance and potential values
     const performanceText = screen.getByText(/Performance:.*High/);
     expect(performanceText).toBeInTheDocument();
+  });
+
+  it("labels current assessment ahead of the newest history year", () => {
+    // Guards against a stale hardcoded year: if history already reaches the
+    // current calendar year, the current assessment must still sort above it.
+    const nextYear = new Date().getFullYear() + 1;
+    const employee = createMockEmployee({
+      ratings_history: [{ year: nextYear, rating: "Leading" }],
+    });
+
+    render(<RatingsTimeline employee={employee} />);
+
+    expect(
+      screen.getByText(
+        getTranslatedText("panel.detailsTab.currentYear", {
+          year: nextYear + 1,
+        })
+      )
+    ).toBeInTheDocument();
   });
 
   it("displays historical ratings sorted by year descending", () => {
@@ -108,7 +129,9 @@ describe("RatingsTimeline", () => {
     // Current year
     expect(
       screen.getByText(
-        getTranslatedText("panel.detailsTab.currentYear", { year: 2025 })
+        getTranslatedText("panel.detailsTab.currentYear", {
+          year: new Date().getFullYear(),
+        })
       )
     ).toBeInTheDocument();
     expect(

--- a/frontend/src/constants/flags.ts
+++ b/frontend/src/constants/flags.ts
@@ -62,7 +62,34 @@ export const FLAGS: Record<string, FlagDefinition> = {
     displayName: "Big Mover",
     color: "#00BCD4", // Cyan
   },
+  medium_mover: {
+    key: "medium_mover",
+    displayName: "Medium Mover",
+    color: "#7986CB", // Indigo
+  },
 };
+
+/**
+ * Flags computed by the backend from movement between calibrations rather than
+ * assigned by a user. They are injected into an employee's flags array so they
+ * filter like any other flag, but they must never be sent back on an update -
+ * the API rejects them as invalid, and they would be recomputed anyway.
+ */
+export const DERIVED_FLAGS: ReadonlySet<string> = new Set([
+  "big_mover",
+  "medium_mover",
+]);
+
+/**
+ * Check whether a flag is computed rather than user-assigned
+ */
+export const isDerivedFlag = (key: string): boolean => DERIVED_FLAGS.has(key);
+
+/**
+ * Strip computed flags, leaving only the user-assigned ones safe to persist
+ */
+export const toPersistableFlags = (flags: string[]): string[] =>
+  flags.filter((flag) => !isDerivedFlag(flag));
 
 /**
  * Get all flag definitions as an array

--- a/frontend/src/constants/positionLabels.ts
+++ b/frontend/src/constants/positionLabels.ts
@@ -65,3 +65,29 @@ export function getPositionName(position: number): string {
 export function getPositionGuidance(position: number): string {
   return getPositionInfo(position).guidance;
 }
+
+/**
+ * Total steps moved across the performance and potential axes between two
+ * grid positions. Mirrors get_axis_distance in the backend employee service:
+ * the grid is a 3x3 of Low/Medium/High per axis, so a diagonal move counts as
+ * one step on each axis rather than one move overall.
+ *
+ * @returns Combined axis steps (0-4), or 0 if either position is out of range
+ */
+export function getAxisDistance(
+  fromPosition: number,
+  toPosition: number
+): number {
+  const inRange = (p: number) => Number.isInteger(p) && p >= 1 && p <= 9;
+  if (!inRange(fromPosition) || !inRange(toPosition)) return 0;
+
+  const fromPerformance = (fromPosition - 1) % 3;
+  const fromPotential = Math.floor((fromPosition - 1) / 3);
+  const toPerformance = (toPosition - 1) % 3;
+  const toPotential = Math.floor((toPosition - 1) / 3);
+
+  return (
+    Math.abs(toPerformance - fromPerformance) +
+    Math.abs(toPotential - fromPotential)
+  );
+}

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -235,7 +235,11 @@
       "addFlag": "Add flag...",
       "box": "Box",
       "flags": "Flags",
-      "noFlagsAvailable": "No flags available"
+      "noFlagsAvailable": "No flags available",
+      "previousCalibration": "Předchozí kalibrace",
+      "movedSteps_one": "posun o {{steps}} stupeň",
+      "movedSteps_other": "posun o {{steps}} stupňů",
+      "movedNoChange": "beze změny"
     },
     "changeTrackerTab": {
       "noChanges": "Zatím žádné změny",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -235,7 +235,11 @@
       "addFlag": "Add flag...",
       "box": "Box",
       "flags": "Flags",
-      "noFlagsAvailable": "No flags available"
+      "noFlagsAvailable": "No flags available",
+      "previousCalibration": "Vorherige Kalibrierung",
+      "movedSteps_one": "{{steps}} Stufe bewegt",
+      "movedSteps_other": "{{steps}} Stufen bewegt",
+      "movedNoChange": "keine Änderung"
     },
     "changeTrackerTab": {
       "noChanges": "Noch keine Änderungen",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -235,7 +235,11 @@
         "level04": "Level 04 (VP)",
         "level05": "Level 05",
         "level06": "Level 06"
-      }
+      },
+      "previousCalibration": "Previous calibration",
+      "movedSteps_one": "moved {{steps}} step",
+      "movedSteps_other": "moved {{steps}} steps",
+      "movedNoChange": "no change"
     },
     "changeTrackerTab": {
       "noChanges": "No changes yet",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -235,7 +235,11 @@
         "level04": "Nivel 04 (VP)",
         "level05": "Nivel 05",
         "level06": "Nivel 06"
-      }
+      },
+      "previousCalibration": "Calibración anterior",
+      "movedSteps_one": "movió {{steps}} nivel",
+      "movedSteps_other": "movió {{steps}} niveles",
+      "movedNoChange": "sin cambios"
     },
     "changeTrackerTab": {
       "noChanges": "Ningún cambio aún",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -235,7 +235,11 @@
       "addFlag": "Add flag...",
       "box": "Box",
       "flags": "Flags",
-      "noFlagsAvailable": "No flags available"
+      "noFlagsAvailable": "No flags available",
+      "previousCalibration": "Calibrage précédent",
+      "movedSteps_one": "a bougé de {{steps}} niveau",
+      "movedSteps_other": "a bougé de {{steps}} niveaux",
+      "movedNoChange": "aucun changement"
     },
     "changeTrackerTab": {
       "noChanges": "Aucune modification",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -235,7 +235,11 @@
       "addFlag": "Add flag...",
       "box": "Box",
       "flags": "Flags",
-      "noFlagsAvailable": "No flags available"
+      "noFlagsAvailable": "No flags available",
+      "previousCalibration": "पिछला कैलिब्रेशन",
+      "movedSteps_one": "{{steps}} चरण बदला",
+      "movedSteps_other": "{{steps}} चरण बदले",
+      "movedNoChange": "कोई बदलाव नहीं"
     },
     "changeTrackerTab": {
       "noChanges": "अभी तक कोई परिवर्तन नहीं",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -235,7 +235,11 @@
       "addFlag": "Add flag...",
       "box": "Box",
       "flags": "Flags",
-      "noFlagsAvailable": "No flags available"
+      "noFlagsAvailable": "No flags available",
+      "previousCalibration": "前回のキャリブレーション",
+      "movedSteps_one": "{{steps}} 段階移動",
+      "movedSteps_other": "{{steps}} 段階移動",
+      "movedNoChange": "変化なし"
     },
     "changeTrackerTab": {
       "noChanges": "変更はまだありません",

--- a/frontend/src/store/sessionStore.ts
+++ b/frontend/src/store/sessionStore.ts
@@ -11,17 +11,21 @@ import { logger } from "../utils/logger";
 import type { CalibrationSummaryData } from "../types/api";
 
 /**
- * Process employees to add "big_mover" to flags array when is_big_mover is true.
- * This ensures the computed backend property is reflected in the frontend flag system.
+ * Process employees to add movement flags ("big_mover", "medium_mover") to the
+ * flags array from the computed backend properties. This makes them filterable
+ * alongside user-assigned flags. They are stripped again before any update is
+ * sent back - see toPersistableFlags.
  */
 function processEmployeesWithBigMoverFlag(employees: Employee[]): Employee[] {
   return employees.map((emp) => {
-    if (emp.is_big_mover) {
-      // Add "big_mover" to flags array if not already present
-      const flags = emp.flags || [];
-      if (!flags.includes("big_mover")) {
-        return { ...emp, flags: [...flags, "big_mover"] };
-      }
+    const derived: string[] = [];
+    if (emp.is_big_mover) derived.push("big_mover");
+    if (emp.is_medium_mover) derived.push("medium_mover");
+
+    const flags = emp.flags || [];
+    const missing = derived.filter((flag) => !flags.includes(flag));
+    if (missing.length > 0) {
+      return { ...emp, flags: [...flags, ...missing] };
     }
     return emp;
   });

--- a/frontend/src/types/employee.ts
+++ b/frontend/src/types/employee.ts
@@ -51,6 +51,7 @@ export interface Employee {
   potential: PotentialLevel;
   grid_position: number; // 1-9
   talent_indicator: string;
+  prior_grid_position?: number | null; // 1-9, position at the previous calibration
 
   // Historical Performance
   ratings_history: HistoricalRating[];
@@ -70,6 +71,7 @@ export interface Employee {
   // Flags (tags for employee status)
   flags?: string[];
   is_big_mover?: boolean; // Computed: true if crossed Low↔High tier
+  is_medium_mover?: boolean; // Computed: true if moved 2+ axis steps without crossing tiers
 
   // Donut Mode (alternative positioning system)
   donut_performance?: PerformanceLevel;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ omit = [
     "*/venv/*",
 ]
 relative_files = true
-concurrency = ["multiprocessing"]
+concurrency = ["multiprocessing", "thread"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
## Description

Three related changes, all surfaced while preparing a real calibration dataset for import.

Performance history was hardcoded to 2023/2024, so any other review cycle was silently dropped on import and lost on export. Separately, nothing compared an employee's 9-box position across calibration cycles — the previous cycle's box arrived only as a free-text talent indicator that no UI or logic read, leaving `is_big_mover` limited to in-session drags and a performance-only annual rating comparison blind to the potential axis.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**Year-agnostic performance history**
- Recognize history columns by pattern (`<4-digit year> Completed Performance Rating`), case-insensitively, returned oldest-first. Blank cells no longer create empty-string ratings, and case variants of one year's header collapse to a single entry.
- Export a column per year present in the data instead of a fixed 2023/2024 pair, shifting trailing columns accordingly so history round-trips for any cycle.
- Derive the sample generator's cycle years from today rather than a fixed `[2023, 2024, 2025]`.
- Label the timeline's current assessment with the current year instead of a hardcoded 2025.

**Movement between calibrations**
- Add `Employee.prior_grid_position`, read from a new `Prior Calibration 9-Box Label` column and written back on export so it round-trips. Both a bare number and a labelled box (`5. Core Talent`) are accepted. Only this explicit column is used — a talent indicator is never inferred from, because that column may hold an older, newer or parallel assessment depending on how the file was assembled.
- Extend `is_big_mover` to compare the prior calibration position against the current one for a Low↔High tier crossing, and restrict its year-over-year check to *completed* years so a current-cycle rating is not compared against the position it describes.
- Add `is_medium_mover` for moves of 2+ steps across the performance and potential axes that do not cross tiers, e.g. Core `[M,M]` → Star `[H,H]`. Mutually exclusive with `is_big_mover` so the filters partition cleanly.
- Surface both as `big_mover` and `medium_mover` flags, filterable alongside user-assigned flags, and show the previous calibration box and distance moved in the detail panel.

**Bug fix along the way**
- Derived flags were injected into the flags array and sent back on update, so adding any flag to a big mover failed with a 422. They are now excluded from update payloads and are no longer offered or removable by hand.

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [x] Added new tests for new functionality
- [x] All existing tests still pass
- [x] Manual testing performed

Backend: 1117 passed, 20 skipped. Frontend: 1406 passed, 11 skipped.

New coverage: arbitrary/out-of-order/lowercase/blank/duplicate history years; prior-position parsing including labelled, out-of-range and infer-nothing cases; export→re-import round-trips for both history and prior position; axis distance; both movement flags and their mutual exclusivity; completed-year filtering; and the derived-flag payload-stripping regression.

Manual verification against a real 93-employee dataset: 93/93 rows parsed with 0 failures, movement flags filter correctly in the UI, and every imported field was diffed back against source workbooks with 0 mismatches.

## Code Quality Checks

- [x] Code follows the style guidelines of this project (ruff format)
- [x] Linting passes (ruff check)
- [x] Type checking passes (pyright, tsc)
- [x] No new warnings introduced
- [x] Self-review of code completed
- [x] Code is properly commented where necessary

Two pre-existing `PLR0917` warnings remain on `get_employees` and `filter_employees`; both signatures are untouched by this PR.

## Screenshots

### Visual Verification

The detail panel gains a previous-calibration line under the current box (`Previous calibration: Core Talent [M,M] — moved 2 steps`), and the flag filter gains `Big Mover` / `Medium Mover` entries. No existing layout changed.

## Deployment Notes

Backward compatible. Files without a `Prior Calibration 9-Box Label` column parse exactly as before and simply produce no calibration-to-calibration flags. New i18n keys added across all seven locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YtDQU2JqkXgsT8HASgkaf

---
_Generated by [Claude Code](https://claude.ai/code/session_014YtDQU2JqkXgsT8HASgkaf)_