### PR TITLE
Prepare 1.1.0 release, and fix empty release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -598,17 +598,17 @@ jobs:
           # Get previous version tag for changelog link
           PREV_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
-          # Extract changelog content for this version
-          # Escape dots in version for regex
-          ESCAPED_VERSION=$(echo "$VERSION" | sed 's/\./\\./g')
-
+          # Extract changelog content for this version.
+          # Uses a flag rather than an awk range: the version heading also matches
+          # the range's end pattern (^## \[), so a range opens and closes on that
+          # same line and yields nothing for every version.
           if [ -f "CHANGELOG.md" ]; then
             # Extract from ## [VERSION] to next ## [ or end of file
-            CHANGELOG_CONTENT=$(awk "/^## \[${ESCAPED_VERSION}\]/,/^## \[/ {
-              if (/^## \[${ESCAPED_VERSION}\]/) next;
-              if (/^## \[/) exit;
-              print
-            }" CHANGELOG.md)
+            CHANGELOG_CONTENT=$(awk -v ver="$VERSION" '
+              index($0, "## [" ver "]") == 1 { inside = 1; next }
+              inside && /^## \[/ { exit }
+              inside { print }
+            ' CHANGELOG.md)
 
             # Trim leading/trailing whitespace
             CHANGELOG_CONTENT=$(echo "$CHANGELOG_CONTENT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -644,7 +644,13 @@ jobs:
             echo ""
             echo "---"
             echo ""
-            echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_VERSION}...v${VERSION}"
+            # No prior tag means there is nothing to compare against; emitting the
+            # link anyway produces compare/...vX.Y.Z, which 404s.
+            if [ -n "$PREV_VERSION" ]; then
+              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_VERSION}...v${VERSION}"
+            else
+              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/commits/v${VERSION}"
+            fi
           } > /tmp/release_notes.md
 
           # Save to output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-27
+
+This release makes calibration history a first-class part of 9Boxer. Your file's full review history now imports regardless of which years it covers, and 9Boxer highlights the people whose placement shifted since your last calibration — so the conversations that need attention surface on their own instead of having to be spotted by eye.
+
+### What's New
+- Employees who moved between calibration cycles are flagged automatically. **Big Mover** marks a reversal across the low and high performance tiers; **Medium Mover** marks a shift of two or more steps across the performance and potential axes without crossing tiers. Both can be filtered on, together or separately.
+- The employee detail panel now shows where someone sat at the previous calibration and how far they moved, directly beneath their current box.
+- Performance history imports for any review year your file contains. Previously only 2023 and 2024 columns were read, so any other cycle was dropped silently on import and lost on export.
+
+### Improvements
+- The performance timeline labels the current assessment with the actual current year rather than a fixed one.
+- Sample data generates its review years relative to today, so it no longer looks stale as time passes.
+- Import accepts a labelled previous-calibration box (for example `5. Core Talent`) as well as a plain number.
+
+### Bug Fixes
+- Adding a flag to an employee marked as a Big Mover no longer fails. The computed flag was being sent back to the server and rejected.
+- Case variations of the same year's history column no longer produce duplicate timeline entries.
+- A rating recorded for the current year is no longer compared against the placement it describes, which previously reported movement that had not happened.
+
 ## [1.0.0] - 2026-01-11
 
 9Boxer v1.0.0 marks our first major release milestone with enhanced application stability and maintenance. The app now updates itself automatically in the background, ensuring you always have the latest features and security improvements without interruption to your workflow.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "9boxer-electron",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "9Boxer - Desktop Application",
   "author": "Your Company",
   "main": "dist-electron/main/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ninebox"
-version = "1.0.0"
+version = "1.1.0"
 description = "9Boxer Application - Backend API"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

Version prep for the 1.1.0 release, plus a fix for the changelog extraction in `release.yml` that has been publishing every release with empty notes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Changes Made

- **`CHANGELOG.md`** — adds the `[1.1.0]` section covering the calibration-movement work merged in #441: the Big Mover / Medium Mover flags, the previous-calibration display in the detail panel, any-year history import, and three bug fixes.
- **`pyproject.toml`** → `1.1.0`. `release.yml` bumps `frontend/package.json` itself but not this file, so the backend would have stayed on `1.0.0` while the app shipped as `1.1.0`.
- **`frontend/package.json`** → `1.1.0`.
- **`.github/workflows/release.yml`** — fixes changelog extraction, plus a guard on the previous-version link (see below).

### Empty release notes

The notes step extracted its content with an awk range:

```awk
/^## \[VERSION\]/,/^## \[/ { if (/^## \[VERSION\]/) next; if (/^## \[/) exit; print }
```

The version heading (`## [1.1.0] - ...`) also matches the range's *end* pattern `^## \[`, so the range opens and closes on that single line; `next` then discards it and nothing is ever printed. This affects every version, not just new ones — the workflow logs `ERROR: No changelog content extracted` and continues, publishing a release with an empty body.

Replaced with a flag-based scan using `index()` on a literal, which also removes the need to regex-escape the version (`ESCAPED_VERSION` is gone).

### Previous-version link guard

`git describe --tags --abbrev=0` returns empty in a repository with no tags, which would render the footer as `compare/...vX.Y.Z` — a 404. Added a fallback to the tag's commit listing when no prior tag exists.

Note this is defensive only; it does not fire for this release. The repository **does** have tags (`v0.9`–`v0.9.4`, `v1.0.0`–`v1.0.3`), and the release job checks out at `fetch-depth: 0`, so `git describe` resolves `v1.0.3` and the 1.1.0 notes will link `compare/v1.0.3...v1.1.0` correctly. An earlier revision of this description claimed the repository had no tags — that was wrong, and is corrected here.

## Testing

- [x] Manual testing performed

Verified against the current `CHANGELOG.md`, before → after:

| Version | Before | After |
|---|---|---|
| `1.0.0` (already released) | 0 chars | 508 chars |
| `0.9` (already released) | 0 chars | 1050 chars |
| `1.1.0` (new) | 0 chars | 1759 chars |
| `9.9.9` (nonexistent) | 0 chars | 0 chars |

`make check-yaml` passes; `pyproject.toml` and `package.json` both parse.

## Deployment Notes

This must land on `main` before `release.yml` is dispatched — the workflow builds from `main`, so releasing first would tag `1.0.0` metadata with empty notes.

Worth a separate look, unrelated to this diff: `CHANGELOG.md` is behind the tags. `v0.9.1`–`v0.9.4`, `v1.0.1`, `v1.0.2`, and `v1.0.3` all shipped without changelog entries, and there are two `## [1.0.0]` headings with different dates. `1.1.0` is still the correct next version (it is ahead of `v1.0.3`), but the `v1.0.3...v1.1.0` diff will contain undocumented work. Deliberately not backfilled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YtDQU2JqkXgsT8HASgkaf